### PR TITLE
feat: add validation for duplicate blocks on a service ID

### DIFF
--- a/registered/validate/validators.py
+++ b/registered/validate/validators.py
@@ -513,6 +513,29 @@ def validate_calendar_exceptions_have_unique_runs(rating):
                 )
 
 
+def validate_services_have_unique_blocks(rating):
+    """
+    Validate that each used service ID has unique block IDs.
+
+    Inside TransitMaster, we only use the last 3 digits of the service ID to
+    identify which blocks/runs are active.
+    """
+    seen = set()
+    for record in rating["blk"]:
+        if not isinstance(record, parser.Block):
+            continue
+        key = (record.block_id, record.service_key)
+        if key in seen:
+            yield ValidationError(
+                file_type="blk",
+                error="duplicate_block_on_service",
+                key=key,
+                description="",
+            )
+        else:
+            seen.add(key)
+
+
 ALL_VALIDATORS = [
     validate_all_blocks_have_trips,
     validate_all_blocks_have_runs,
@@ -520,6 +543,7 @@ ALL_VALIDATORS = [
     validate_all_runs_have_blocks,
     validate_block_garages,
     validate_calendar_exceptions_have_unique_runs,
+    validate_services_have_unique_blocks,
     validate_no_extra_timepoints,
     validate_pattern_stop_has_node,
     validate_routes_have_two_directions,

--- a/tests/support/validation/invalid/duplicate_block_on_service_id/EXPECTED_ERRORS.txt
+++ b/tests/support/validation/invalid/duplicate_block_on_service_id/EXPECTED_ERRORS.txt
@@ -1,0 +1,1 @@
+key=('B24-7', '016'), error='duplicate_block_on_service'

--- a/tests/support/validation/invalid/duplicate_block_on_service_id/blocks.blk
+++ b/tests/support/validation/invalid/duplicate_block_on_service_id/blocks.blk
@@ -1,0 +1,2 @@
+BLK;    B24-7;   4680526;6      ;arbor ;0534a;matpn ;0550a;ashmt ;1029a;arbor ;1045a;    ;    ;        ;016;;
+BLK;    B24-7;   4680600;6      ;arbor ;1029a;ashmt ;1045a;ashmt ;1150a;arbor ;1206p;    ;    ;        ;016;;


### PR DESCRIPTION
I checked this validation against the invalid one Dan provided, and it correctly warns about that export and not about the subsequent valid exports.