### PR TITLE
fix: raise a better error when Universal dir isn't found

### DIFF
--- a/registered/hastus_sync.py
+++ b/registered/hastus_sync.py
@@ -152,17 +152,24 @@ def pull_prior_versions(tempdir):
         ),
         tempdir / "PriorVersions" / "svc-desc.txt",
     )
-    annun_dirs = smbclient.listdir(
-        smb_path(
-            TRANSITMASTER_DB,
-            "e$",
-            "FTP_ROOT",
-            "Operational Data",
-            "Announcements",
-            "Current_Release",
-        )
+    annun_path = smb_path(
+        TRANSITMASTER_DB,
+        "e$",
+        "FTP_ROOT",
+        "Operational Data",
+        "Announcements",
+        "Current_Release",
     )
-    universal_dir = sorted(dir for dir in annun_dirs if "Universal" in dir)[0]
+
+    annun_dirs = smbclient.listdir(annun_path)
+    try:
+        universal_dir = sorted(dir for dir in annun_dirs if "Universal" in dir)[0]
+    except IndexError:
+        # pylint: disable=raise-missing-from
+        raise RuntimeError(
+            f"unable to find Universal announcements in {annun_path}\n"
+            f"Found: {annun_dirs!r}"
+        )
     smbclient.shutil.copyfile(
         smb_path(
             TRANSITMASTER_DB,


### PR DESCRIPTION
We look for the current ANN2DEST file in the Universal announcements on
the TransitMaster DB server. Previously, if we didn't find it, we'd
raise a cryptic `IndexError`. Now, we raise a friendlier `RuntimeError`:

```
RuntimeError: unable to find Universal announcements in \\hstmcldb\e$\FTP_ROOT\Operational Data\Announcements\Current_Release
Found: ['071522_BRND']
```